### PR TITLE
Fix: Use default values for source directory and ref

### DIFF
--- a/operator/docker/init-sources
+++ b/operator/docker/init-sources
@@ -43,8 +43,8 @@ def fetch_source [config] {
       $repo = $"($parsed.scheme)://($username):($password)@($parsed.host)($parsed.path)"
     }
   }
-  let dir = $query.dir
-  let ref = $query.ref
+  let dir = ($query | get dir --ignore-errors | default "")
+  let ref = ($query | get ref --ignore-errors | default "")
 
   git clone $repo $tmp_dir
 


### PR DESCRIPTION
- Updates the `fetch_source` function to retrieve the source directory and ref using `get` with `--ignore-errors` and defaulting to empty strings.
- Eliminates potential errors when the directory or ref is not found in the query.
- Ensures the program gracefully handles missing query parameters.