### PR TITLE
Add Buildx workflow for Docker image build and push

### DIFF
--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -1,0 +1,50 @@
+---
+name: Build and Push Docker Images
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ck3mp3r/nuop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate tags
+        id: tags
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          else
+            echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./operator
+          file: ./operator/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ build:
 	kind load docker-image $(REGISTRY)/$(IMAGE_NAME):latest -n nuop 
 	
 buildx:
-	docker buildx create --name mybuilder --use || true
-	docker buildx inspect --bootstrap
-	docker buildx build -f ./operator/docker/Dockerfile --platform linux/amd64,linux/arm64 -t $(REGISTRY)/$(IMAGE_NAME):$(VERSION) --push ./operator
+	cd operator && docker buildx create --name mybuilder --use || true
+	cd operator && docker buildx inspect --bootstrap
+	cd operator && docker buildx build -f docker/Dockerfile --platform linux/amd64,linux/arm64 -t $(REGISTRY)/$(IMAGE_NAME):$(VERSION) --push .
 
 clean:
 	cd operator && cargo clean
@@ -38,3 +38,15 @@ act-test:
 		-P ubuntu-latest=catthehacker/ubuntu:js-latest \
 		-W .github/workflows/test.yaml \
 		-j test
+
+act-buildx:
+	@act workflow-dispatch \
+		--rm \
+		--container-architecture linux/aarch64 \
+		--privileged \
+		--container-daemon-socket /var/run/docker.sock \
+		-s GITHUB_TOKEN=${GITHUB_TOKEN} \
+		-s ACTIONS_RUNTIME_TOKEN=${GITHUB_TOKEN} \
+		-P ubuntu-latest=catthehacker/ubuntu:js-latest \
+		-W .github/workflows/buildx.yaml \
+		-j build


### PR DESCRIPTION
- Introduces a new GitHub Actions workflow named `buildx` to build and push Docker images.
- Configures a Docker Buildx environment within the `operator` directory using `docker buildx create` and `docker buildx inspect`.
- Leverages `docker/build-push-action` to build and push Docker images to GitHub Container Registry (GHCR).
- Sets up image tags based on the branch reference (`main` vs. other branches).
- Includes a Dockerfile located in the `./operator/docker` directory for image building.
- Creates an `act-buildx` target in the Makefile to execute the new Buildx workflow.