### PR TITLE
Add QEMU setup to buildx workflow

### DIFF
--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
- Adds a QEMU setup action before the Docker Buildx setup.
- Ensures that QEMU is initialized as a prerequisite for cross-platform container builds.
- Enables the buildx workflow to correctly emulate different architectures.