### PR TITLE
Use short git hash for image tags

### DIFF
--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -38,7 +38,7 @@ jobs:
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
           else
-            echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push Docker image


### PR DESCRIPTION
- Uses `git rev-parse --short HEAD` to generate shortened commit hashes for image tags.
- Ensures that image tags reflect the short commit hash when not building from the `main` branch.
- Improves readability and brevity of image tags.