### PR TITLE
Refactor: Update workflow concurrency group

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,14 @@ name: Test
 
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - flake.*
+      - devshell.toml
+      - operator/Cargo.*
+      - operator/flake.*
+      - operator/src/**
+      - .github/workflows/**
   pull_request:
     paths:
       - flake.*
@@ -13,7 +21,7 @@ on:
       - .github/workflows/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
- Modifies the concurrency group to use `github.head_ref` instead of `github.event.pull_request.number`.
- This change ensures the concurrency group is correctly defined for push workflows, avoiding potential concurrency issues.
- Resolves a problem where push events could unintentionally share a concurrency group with pull request events.
- Enables accurate concurrency management across workflow types.